### PR TITLE
visit members when considering imports to add

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "cxsd": "bin/cxsd"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc --sourceMap -p tsconfig.json",
     "test": "npm-run-all test:*",
     "test:build": "npm-run-all test:build:*",
     "test:build:clean": "mkdir -p cache && rm -rf cache && cd test && mkdir -p cache && rm -rf cache && mkdir -p xmlns && rm -rf xmlns && cd ..",

--- a/src/schema/transform/AddImports.ts
+++ b/src/schema/transform/AddImports.ts
@@ -17,6 +17,10 @@ export class AddImports extends Transform<AddImports, Output, void> {
       if (type) this.visitType(type);
     }
 
+    for (var member of this.namespace.memberList) {
+      if (member) this.visitMember(member);
+    }
+
     this.namespace.importContentTbl = this.output;
 
     return this.output;


### PR DESCRIPTION
This fixes an issue where types used by imported AttributeGroups are not themselves imported into the compiled schema.

For example, if I have an XSD that imports an AttributeGroup (`AG1`) from another XSD/namespace (`NS2`), cxsd does not currently mark any of the types used in AG1 as being used by NS2, and excludes them from the compiled `.js` output if they aren't also used outside of an AttributeGroup (ie. in within a `ComplexType` definition).

If `AG1` contains an attribute with type `xml:Date`, the compiled `.js` schema won't contain any references to `Date`, and will throw warnings when loaded by `cxml` (`Member with multiple types`, although it's an inaccurate message -- the member actually has 0 types).  